### PR TITLE
chore: bumped to EDC 0.10.0

### DIFF
--- a/gradle/libs.stable.versions.toml
+++ b/gradle/libs.stable.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.9.1"
+edc = "0.10.0"
 postgres = "42.7.4"
 
 # add here
@@ -31,6 +31,7 @@ edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-jersey-core = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-jetty-core = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
 edc-configuration-filesystem = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
+edc-token-core = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
 
 # Control Plane-specific dependencies
 edc-controlplane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
@@ -105,10 +106,11 @@ controlplane = ["edc-configuration-filesystem", "edc-controlplane-core", "edc-au
     "edc-api-management", "edc-api-management-config", "edc-api-management-edr", "edc-api-management-dataplaneselector",
     "edc-api-observability", "edc-dsp", "edc-spi-jwt", "edc-http", "edc-controlplane-callback-dispatcher-event",
     "edc-controlplane-callback-dispatcher-http", "edc-identity-core-did", "edc-iam-mock", "edc-identity-trust-transform",
-    "edc-api-control-configuration", "edc-lib-transform", "edc-identity-vc-ldp", "edc-did-web", "edc-lib-jws2020", "edc-core-edrstore", "edc-edr-storereceiver"]
+    "edc-api-control-configuration", "edc-lib-transform", "edc-identity-vc-ldp", "edc-did-web", "edc-lib-jws2020", "edc-core-edrstore",
+    "edc-edr-storereceiver", "edc-token-core"]
 
 dataplane = ["edc-configuration-filesystem", "edc-jersey-core", "edc-jetty-core", "edc-dataplane-core", "edc-dataplane-api-control-config", "edc-dataplane-api-control-client", "edc-dataplane-selfregistration",
-    "edc-dataplane-http", "edc-dataplane-http-oauth2", "edc-dataplane-api-public", "edc-dataplane-api-signaling", "edc-dataplane-iam"]
+    "edc-dataplane-http", "edc-dataplane-http-oauth2", "edc-dataplane-api-public", "edc-dataplane-api-signaling", "edc-dataplane-iam", "edc-token-core"]
 
 sql-controlplane = ["edc-sql-assetindex", "edc-sql-contractdef", "edc-sql-contractneg", "edc-sql-policydef",
     "edc-sql-edrcache", "edc-sql-transferprocess", "edc-sql-dataplane-instancestore", "edc-sql-core", "edc-sql-lease", "edc-sql-policymonitor",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.10.0-SNAPSHOT"
+edc = "0.11.0-SNAPSHOT"
 postgres = "42.7.4"
 jakarta-json = "2.1.3"
 jackson = "2.18.0"
@@ -33,6 +33,7 @@ edc-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 edc-jersey-core = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-jetty-core = { module = "org.eclipse.edc:jetty-core", version.ref = "edc" }
+edc-token-core = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
 
 # Control Plane-specific dependencies
 edc-controlplane-core = { module = "org.eclipse.edc:control-plane-core", version.ref = "edc" }
@@ -111,14 +112,14 @@ testcontainers-postgres = { module = "org.testcontainers:postgresql", version.re
 [bundles]
 dpf = ["edc-dpf-selector-core", "edc-spi-dataplane-selector", "edc-dpf-selector-control-api", "edc-dpf-signaling-client", "edc-dpf-transfer-signaling"]
 
-controlplane = ["edc-controlplane-core", "edc-auth-tokenbased", "edc-auth-configuration", "edc-policy-monitor-core",
+controlplane = ["edc-token-core", "edc-controlplane-core", "edc-auth-tokenbased", "edc-auth-configuration", "edc-policy-monitor-core",
     "edc-api-management", "edc-api-management-config", "edc-api-management-edr", "edc-api-management-dataplaneselector",
     "edc-api-observability", "edc-dsp", "edc-spi-jwt", "edc-http", "edc-controlplane-callback-dispatcher-event",
     "edc-controlplane-callback-dispatcher-http", "edc-identity-core-did", "edc-iam-mock", "edc-identity-trust-transform",
     "edc-api-control-configuration", "edc-lib-transform", "edc-identity-vc-ldp", "edc-did-web", "edc-lib-jws2020", "edc-core-edrstore", "edc-edr-storereceiver"]
 
 dataplane = ["edc-jersey-core", "edc-jetty-core", "edc-dataplane-core", "edc-dataplane-api-control-config", "edc-dataplane-api-control-client", "edc-dataplane-selfregistration",
-    "edc-dataplane-http", "edc-dataplane-http-oauth2", "edc-dataplane-api-public", "edc-dataplane-api-signaling", "edc-dataplane-iam"]
+    "edc-dataplane-http", "edc-dataplane-http-oauth2", "edc-dataplane-api-public", "edc-dataplane-api-signaling", "edc-dataplane-iam", "edc-token-core"]
 
 sql-controlplane = ["edc-sql-assetindex", "edc-sql-contractdef", "edc-sql-contractneg", "edc-sql-policydef",
     "edc-sql-edrcache", "edc-sql-transferprocess", "edc-sql-dataplane-instancestore", "edc-sql-core", "edc-sql-lease", "edc-sql-policymonitor",

--- a/runtimes/snapshot/dataplane-snapshot/build.gradle.kts
+++ b/runtimes/snapshot/dataplane-snapshot/build.gradle.kts
@@ -19,14 +19,14 @@ plugins {
 }
 
 dependencies {
-    runtimeOnly(stableLibs.edc.api.observability)
-    runtimeOnly(stableLibs.bundles.dataplane)
-    runtimeOnly(stableLibs.edc.jsonld) // needed by the DataPlaneSignalingApi
-    runtimeOnly(stableLibs.edc.dpf.selector.client) // for the selector service -> self registration
+    runtimeOnly(libs.edc.api.observability)
+    runtimeOnly(libs.bundles.dataplane)
+    runtimeOnly(libs.edc.jsonld) // needed by the DataPlaneSignalingApi
+    runtimeOnly(libs.edc.dpf.selector.client) // for the selector service -> self registration
 
     // uncomment the following lines to compile with Hashicorp Vault and Postgres persistence
     // runtimeOnly(stableLibs.edc.vault.hashicorp)
-    runtimeOnly(stableLibs.bundles.sql.dataplane)
+    runtimeOnly(libs.bundles.sql.dataplane)
 
 }
 


### PR DESCRIPTION
## What this PR changes/adds

bumped to EDC 0.10.0 and adds testing also on `dataspace-protocol-http:2024/1` protocol

Additionally added test with transfer suspend/resume

## Why it does that

backward compatibility check

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
