### PR TITLE
chore: bumps stable EDC to 0.10.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@
 #
 #
 group=org.eclipse.edc
-version=0.10.0-SNAPSHOT
+version=0.11.0-SNAPSHOT
 edcScmUrl=https://github.com/eclipse-edc/CompatibilityTests.git
 edcScmConnection=scm:git:git@github.com:eclipse-edc/CompatibilityTests.git

--- a/gradle/libs.stable.versions.toml
+++ b/gradle/libs.stable.versions.toml
@@ -2,7 +2,7 @@
 format.version = "1.1"
 
 [versions]
-edc = "0.10.0"
+edc = "0.10.1"
 postgres = "42.7.4"
 
 # add here


### PR DESCRIPTION
## What this PR changes/adds

bumps stable EDC to 0.10.1


